### PR TITLE
Windows以外のOSへの対応

### DIFF
--- a/Debug.py
+++ b/Debug.py
@@ -25,10 +25,6 @@ def DebugInput():
 def GetAllFileName():
     return glob.glob(os.path.join(tcm.testCaseDirec, "*"))
 
-def InitResultFile():
-    f = open(os.path.join(outPath, fl.GetOutputFilePath(), fl.GetOutputFileName()), 'a')
-    f.close()
-
 messages = []
 def ExacMain():
     try:
@@ -75,12 +71,10 @@ def main():
         #テストケース実行
         fl.SetFileName(testCaseName, "main")
         fl.SetFileContents()
-        InitResultFile()
         ExacMain()
 
         fl.SetFileName(testCaseName, "greedy")
         fl.SetFileContents()
-        InitResultFile()
         ExacGreedy()
 
         #比較

--- a/Debug.py
+++ b/Debug.py
@@ -6,14 +6,14 @@ import TestCaseMaker as tcm
 import FileLib as fl
 import filecmp
 
-outPath = "out\\"
+outPath = "out"
 outFile = "Result"
 
 ####################################
 #Debug用の入出力
 
 def DebugPrint(*arg, **keys):
-    f = open(outPath + fl.GetOutputFilePath() + "\\" + fl.GetOutputFileName(), 'a')
+    f = open(os.path.join(outPath, fl.GetOutputFilePath(), fl.GetOutputFileName()), 'a')
     print(*arg, **keys, file=f)
     f.close()
 
@@ -23,10 +23,10 @@ def DebugInput():
 ####################################
 
 def GetAllFileName():
-    return glob.glob(tcm.testCaseDirec + "*")
+    return glob.glob(os.path.join(tcm.testCaseDirec, "*"))
 
 def InitResultFile():
-    f = open(outPath + fl.GetOutputFilePath() + "\\" + fl.GetOutputFileName(), 'a')
+    f = open(os.path.join(outPath, fl.GetOutputFilePath(), fl.GetOutputFileName()), 'a')
     f.close()
 
 messages = []
@@ -38,7 +38,7 @@ def ExacMain():
         errMessage = str(fileName + e)
         messages.append(errMessage)
     if "main" in sys.modules: del sys.modules["main"]
-    
+
 def ExacGreedy():
     try:
         import greedy
@@ -70,7 +70,7 @@ result = []
 def main():
     InitResult()
     allTestCaseName = GetAllFileName()
-    
+
     for testCaseName in allTestCaseName:
         #テストケース実行
         fl.SetFileName(testCaseName, "main")
@@ -84,14 +84,14 @@ def main():
         ExacGreedy()
 
         #比較
-        path = outPath + fl.GetOutputFilePath() + "\\"
-        file = glob.glob(path + "*")
+        path = os.path.join(outPath, fl.GetOutputFilePath(), "*")
+        file = glob.glob(path)
         if len(file) != 2:
             pass
         elif not filecmp.cmp(*file):
-            fileName = testCaseName.split("\\")[:-1]
+            fileName = os.path.basename(testCaseName)
             result.append(fileName)
-    
+
     MakeResultFile()
 
 if __name__ == "__main__":

--- a/Debug.py
+++ b/Debug.py
@@ -44,8 +44,7 @@ def ExacGreedy():
     if "greedy" in sys.modules: del sys.modules["greedy"]
 
 def InitResult():
-    try: shutil.rmtree(outPath)
-    except: pass
+    shutil.rmtree(outPath, ignore_errors=True)
     os.mkdir(outPath)
 
 def MakeResultFile():

--- a/FileLib.py
+++ b/FileLib.py
@@ -1,6 +1,5 @@
 import Debug as dl
 import os
-import glob
 
 inputFileName = ""
 outputFileName = ""
@@ -9,12 +8,9 @@ def SetFileName(testCaseName, module):
     global inputFileName, outputFileName, outFilePath
     inputFileName = testCaseName
     outputFileName = module + ".txt"
-    outFilePath = os.path.basename(testCaseName)
-    outFilePath = outFilePath.split(".")[0]
+    outFilePath = os.path.basename(testCaseName).split(".")[0]
 
-    d = glob.glob(os.path.join(dl.outPath, "*"))
-    if os.path.join(dl.outPath, outFilePath) not in d:
-        os.mkdir(os.path.join(dl.outPath, outFilePath))
+    os.makedirs(os.path.join(dl.outPath, outFilePath), exist_ok=True)
 def GetInputFileName():
     return inputFileName
 def GetOutputFileName():

--- a/FileLib.py
+++ b/FileLib.py
@@ -9,12 +9,12 @@ def SetFileName(testCaseName, module):
     global inputFileName, outputFileName, outFilePath
     inputFileName = testCaseName
     outputFileName = module + ".txt"
-    outFilePath = testCaseName.split("\\")[-1]
+    outFilePath = os.path.basename(testCaseName)
     outFilePath = outFilePath.split(".")[0]
 
-    d = glob.glob(dl.outPath + "*")
-    if dl.outPath + outFilePath not in d:
-        os.mkdir(dl.outPath + outFilePath)
+    d = glob.glob(os.path.join(dl.outPath, "*"))
+    if os.path.join(dl.outPath, outFilePath) not in d:
+        os.mkdir(os.path.join(dl.outPath, outFilePath))
 def GetInputFileName():
     return inputFileName
 def GetOutputFileName():

--- a/TestCaseMaker.py
+++ b/TestCaseMaker.py
@@ -3,9 +3,10 @@
 """
 
 import random
+import os
 
 testCaseNum = 10
-testCaseDirec = "in\\"
+testCaseDirec = "in"
 testCaseFileName = "case"
 
 ####################################
@@ -25,7 +26,7 @@ def MakeTestCase():
 def PrintTestCase(*arg, **keys):
     global idx
     fileName = testCaseFileName + str(idx+1) + ".txt"
-    f = open(testCaseDirec + fileName, 'a')
+    f = open(os.path.join(testCaseDirec, fileName), 'a')
     print(*arg, **keys, file=f)
     f.close()
 
@@ -34,7 +35,7 @@ def PrintTestCase(*arg, **keys):
 def InitFile():
     global idx
     fileName = testCaseFileName + str(idx+1) + ".txt"
-    f = open(testCaseDirec + fileName, 'w')
+    f = open(os.path.join(testCaseDirec, fileName), 'w')
     f.close()
 
 idx = 0
@@ -79,7 +80,7 @@ def MakeRandomString(length=10,same="True"):
     for i in range(length):
         r = 0
         if same: r = random.randint(0,1)
-        
+
         if r == 0 and len(s):
             p = random.randint(0, len(s)-1)
             ret += list(s)[p]


### PR DESCRIPTION
# 概要

主にファイルパス部分を[os.path.join](https://docs.python.org/ja/3/library/os.path.html#os.path.join)を使うことでWindows以外のOSへも対応させた。

# 確認

- [x] Mac
  - [x] mainとgreedyで結果が同じ場合
  - [x] mainとgreedyで結果が違う場合
- [ ] Windows
  - [ ] mainとgreedyで結果が同じ場合
  - [ ] mainとgreedyで結果が違う場合
