### PR TITLE
型ヒントを追加

### DIFF
--- a/Debug.py
+++ b/Debug.py
@@ -2,13 +2,17 @@
 Solve1.pyとSolve2.pyをそれぞれのテストケースで実行し、実行結果の差を出力する
 """
 
+from __future__ import annotations
+
 import sys
 import glob
 import os
 import shutil
+import filecmp
+from typing import Any
+
 import TestCaseMaker as tcm
 import FileLib as fl
-import filecmp
 
 outPath = "out"
 outFile = "Result"
@@ -16,24 +20,24 @@ outFile = "Result"
 ####################################
 #Debug用の入出力
 
-def DebugPrint(*arg, **keys):
+def DebugPrint(*arg: Any, **keys: Any) -> None:
     """実行結果をファイルに出力させる"""
     f = open(os.path.join(outPath, fl.GetOutputFilePath(), fl.GetOutputFileName()), 'a')
     print(*arg, **keys, file=f)
     f.close()
 
-def DebugInput():
+def DebugInput() -> str:
     """入力をテストケースから読み取る"""
     return str(fl.fileContents.pop())
 
 ####################################
 
-def GetAllFileName():
+def GetAllFileName() -> list[str]:
     """すべてのテストケースファイルを取得する"""
     return glob.glob(os.path.join(tcm.testCaseDirec, "*"))
 
 messages = []
-def ExacSolve1():
+def ExacSolve1() -> None:
     """Solve1.pyを実行して結果を記録する"""
     try:
         import Solve1
@@ -46,7 +50,7 @@ def ExacSolve1():
         messages.append(errMessage)
     if "Solve1" in sys.modules: del sys.modules["Solve1"]
 
-def ExacSolve2():
+def ExacSolve2() -> None:
     """Solve2.pyを実行して結果を記録する"""
     try:
         import Solve2
@@ -59,12 +63,12 @@ def ExacSolve2():
         messages.append(errMessage)
     if "Solve2" in sys.modules: del sys.modules["Solve2"]
 
-def InitResult():
+def InitResult() -> None:
     """実行結果の出力先ディレクトリを初期化する"""
     shutil.rmtree(outPath, ignore_errors=True)
     os.mkdir(outPath)
 
-def MakeResultFile():
+def MakeResultFile() -> None:
     """実行結果ファイルを作成する"""
     f = open("result.txt", 'w')
     if not len(result):
@@ -80,7 +84,7 @@ def MakeResultFile():
         print(*messages, sep="\n", file=f)
 
 result = []
-def main():
+def main() -> None:
     InitResult()
     allTestCaseName = GetAllFileName()
 

--- a/FileLib.py
+++ b/FileLib.py
@@ -8,7 +8,7 @@ import os
 inputFileName = ""
 outputFileName = ""
 outFilePath = ""
-def SetFileName(testCaseName, module):
+def SetFileName(testCaseName: str, module: str) -> None:
     """実行するテストケースとその結果ファイルを一時的に記録"""
     global inputFileName, outputFileName, outFilePath
     inputFileName = testCaseName
@@ -16,18 +16,18 @@ def SetFileName(testCaseName, module):
     outFilePath = os.path.basename(testCaseName).split(".")[0]
 
     os.makedirs(os.path.join(dl.outPath, outFilePath), exist_ok=True)
-def GetInputFileName():
+def GetInputFileName() -> str:
     """実行するテストケースファイル名を取得"""
     return inputFileName
-def GetOutputFileName():
+def GetOutputFileName() -> str:
     """実行結果の出力先のファイル名を取得"""
     return outputFileName
-def GetOutputFilePath():
+def GetOutputFilePath() -> str:
     """実行結果の出力先パスを取得"""
     return outFilePath
 
 fileContents = []
-def SetFileContents():
+def SetFileContents() -> None:
     """テストケースの各行を読み込みfileContentsに保存"""
     global fileContents
     path = GetInputFileName()

--- a/TestCaseMaker.py
+++ b/TestCaseMaker.py
@@ -2,10 +2,17 @@
 テストケースを作成する
 """
 
+from __future__ import annotations
+
 import random
 import os
 import shutil
+from typing import Any, Union, Literal, Optional
+
 from MyLib import *
+
+Number = Union[int, float]
+NumberType = Literal['int', 'float']
 
 testCaseNum = 10
 testCaseDirec = "in"
@@ -13,7 +20,7 @@ testCaseFileName = "case"
 
 ####################################
 
-def MakeTestCase():
+def MakeTestCase() -> None:
     """テストケースの入力形式を書く"""
     # Write Code Here
     n = MakeRandomValue(2, 10)
@@ -25,7 +32,7 @@ def MakeTestCase():
     PrintTestCase(*a)
     PrintTestCase(*b)
 
-def PrintTestCase(*arg, **keys):
+def PrintTestCase(*arg: Any, **keys: Any) -> None:
     """ファイルに出力"""
     global idx
     fileName = testCaseFileName + str(idx+1) + ".txt"
@@ -36,7 +43,7 @@ def PrintTestCase(*arg, **keys):
 ####################################
 
 idx = 0
-def MakeAllTestCase():
+def MakeAllTestCase() -> None:
     """全テストケースを作成"""
     global testCaseNum
     for i in range(testCaseNum):
@@ -58,7 +65,7 @@ def MakeAllTestCase():
 #       説明文の後ろの"defaultValue"がデフォルト値になります
 #       引数を指定するときは func(key=value) のようにして値を与えてください
 
-def MakeRandomValue(minVal, maxVal, type="int", keta=9):
+def MakeRandomValue(minVal: Number, maxVal: Number, type: NumberType = 'int', keta: int = 9) -> Number:
     """値を生成する
 
     引数
@@ -77,7 +84,7 @@ def MakeRandomValue(minVal, maxVal, type="int", keta=9):
     if type == "float": return round(random.uniform(minVal, maxVal), keta)
     assert 0, "type error in MakeRandomValue()"
 
-def MakeRandomString(length=10,same="True"):
+def MakeRandomString(length: int = 10, same: bool = True) -> str:
     """アルファベット小文字のみの文字列を生成する
 
     引数
@@ -104,7 +111,8 @@ def MakeRandomString(length=10,same="True"):
             s.add(c)
     return ret
 
-def MakeRandomArray(length, minVal, maxVal, type="int", permutation=False, order=None):
+def MakeRandomArray(length: int, minVal: Number, maxVal, type: NumberType | Literal['str'] = 'int',
+                    permutation: bool = False, order: Optional[Literal['U', 'D']] = None) -> list[Number | str]:
     """配列の作成
     引数
         ◆length
@@ -140,8 +148,9 @@ def MakeRandomArray(length, minVal, maxVal, type="int", permutation=False, order
     elif order == "D": ret = sorted(ret, reverse=True)
     return ret
 
-def MakeRandomGraph(N, M, weight=False, weightMin=1, weightMax=100,\
-    tree=False, connect=False, selfEdge=False, multiEdge=False, index=1):
+def MakeRandomGraph(N: int, M: int, weight: bool = False, weightMin: int = 1,
+                    weightMax: int = 100, tree: bool = False, connect: bool = False,
+                    selfEdge: bool = False, multiEdge: bool = False, index: bool = 1) -> tuple[int, list[int]]:
     """グラフの生成
 
     戻り値の形式
@@ -216,7 +225,8 @@ def MakeRandomGraph(N, M, weight=False, weightMin=1, weightMax=100,\
     random.shuffle(ret)
     return M, ret
 
-def Check(N,edgeNum,u,v,edgeSet,uf,tree,connect,selfEdge,multiEdge):
+def Check(N: int, edgeNum: int, u: int, v: int, edgeSet: set[list[tuple[int, int]]],
+          uf: UnionFind, tree: bool, connect: bool, selfEdge: bool, multiEdge: bool) -> bool:
     """引数で指定したグラフになるかどうかを判定"""
     if not selfEdge: #自己辺を許さなくてu=vならFalse
         if u == v: return False
@@ -227,7 +237,7 @@ def Check(N,edgeNum,u,v,edgeSet,uf,tree,connect,selfEdge,multiEdge):
         if (u,v) in edgeSet or (v,u) in edgeSet: return False
     return True
 
-def InitTestCaseDirectory():
+def InitTestCaseDirectory() -> None:
     """テストケースディレクトリの初期化"""
     shutil.rmtree(testCaseDirec, ignore_errors=True)
     os.mkdir(testCaseDirec)


### PR DESCRIPTION
# 概要

MakeRandomGraphなどの関数が変数多すぎて、どれがどの型を使うか分かりづらかったため、すべての関数に型ヒントを追加。AtCoderのサポートと合わせて、python 3.8以上に対応。

型ヒントをつけると、VSCodeで関数にマウスオーバーすると、どんな型の引数があるのかわかるようになる。
![スクリーンショット 2022-01-18 0 43 37](https://user-images.githubusercontent.com/7848194/149953907-df404162-0f15-4d38-93da-09924d426a0c.png)


# 今後の運用

型ヒントはつけてもつけなくても挙動になんの変化もないので、無理につけようとしなくても、つけたいときにつければいいと思う。


# 参考

2021年版Pythonの型ヒントの書き方 (for Python 3.9)
https://future-architect.github.io/articles/20201223/