### PR TITLE
プログラムの実行方法変更

### DIFF
--- a/Debug.py
+++ b/Debug.py
@@ -4,13 +4,11 @@ Solve1.pyとSolve2.pyをそれぞれのテストケースで実行し、実行�
 
 from __future__ import annotations
 
-import sys
 import glob
 import os
 import shutil
 import filecmp
-from typing import Any
-import traceback
+from typing import Tuple
 import subprocess
 
 import TestCaseMaker as tcm
@@ -29,41 +27,22 @@ def GetAllFileName() -> list[str]:
     return glob.glob(os.path.join(tcm.testCaseDirec, "*"))
 
 messages = []
-def ExacSolve1(status: ResultStatus) -> None:
-    """Solve1.pyを実行して実行結果を引数で与えられたクラスに記録する"""
+def ExacCommand(command: str) -> Tuple[bool, str|None]:
+    """与えられたコマンドを実行してエラーフラグとエラーメッセージを出力する"""
     errFlg = False
     errMsg = None
 
     inFile = fl.GetInputFileName()
     outFile = fl.GetOutputFileName()
 
-    res = subprocess.run(cmd.format(name=prog1, inFile=inFile, outFile=outFile),
+    res = subprocess.run(cmd.format(name=command, inFile=inFile, outFile=outFile),
      encoding='utf-8', stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True)
     
     if res.returncode != 0:
         errMsg = res.stderr
         errFlg = True
     
-    status.errFlg1 = errFlg
-    status.errMsg1 = errMsg
-
-def ExacSolve2(status: ResultStatus) -> None:
-    """Solve2.pyを実行して実行結果を引数で与えられたクラスに記録する"""
-    errFlg = False
-    errMsg = None
-
-    inFile = fl.GetInputFileName()
-    outFile = fl.GetOutputFileName()
-
-    res = subprocess.run(cmd.format(name=prog2, inFile=inFile, outFile=outFile),
-     encoding='utf-8', stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True)
-    
-    if res.returncode != 0:
-        errMsg = res.stderr
-        errFlg = True
-    
-    status.errFlg2 = errFlg
-    status.errMsg2 = errMsg
+    return errFlg, errMsg
 
 def InitResult() -> None:
     """実行結果の出力先ディレクトリを初期化する"""
@@ -85,10 +64,12 @@ def ExacTestCaseAndRecordResult(testCasePath: str) -> ResultStatus:
 
     #Solve1.py実行
     fl.SetFileName(testCasePath, "Solve1")
-    ExacSolve1(status)
+    errFlg, errMsg = ExacCommand(prog1)
+    status.errFlg1 = errFlg; status.errMsg1 = errMsg
     #Solve2.py実行
     fl.SetFileName(testCasePath, "Solve2")
-    ExacSolve2(status)
+    errFlg, errMsg = ExacCommand(prog2)
+    status.errFlg2 = errFlg; status.errMsg2 = errMsg
 
     #比較対象のファイルをGet
     files = glob.glob(os.path.join(fl.outPath, fl.GetOutputFilePath(), "*"))

--- a/Debug.py
+++ b/Debug.py
@@ -18,8 +18,6 @@ import FileLib as fl
 from MyLib import GetIndex, ResultStatus, AllResultStatus
 from Output import StandardOutput, FileOutput, HTMLOutput
 
-outPath = "out"
-
 prog1 = "solve1.py"
 prog2 = "solve2.py"
 cmd = "python {name} < {inFile} > {outFile}"
@@ -37,7 +35,7 @@ def ExacSolve1(status: ResultStatus) -> None:
     errMsg = None
 
     inFile = fl.GetInputFileName()
-    outFile = "out\\case" + str(status.idx) + "\\"+ fl.GetOutputFileName()
+    outFile = fl.GetOutputFileName()
 
     res = subprocess.run(cmd.format(name=prog1, inFile=inFile, outFile=outFile),
      encoding='utf-8', stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True)
@@ -55,7 +53,7 @@ def ExacSolve2(status: ResultStatus) -> None:
     errMsg = None
 
     inFile = fl.GetInputFileName()
-    outFile = "out\\case" + str(status.idx) + "\\"+ fl.GetOutputFileName()
+    outFile = fl.GetOutputFileName()
 
     res = subprocess.run(cmd.format(name=prog2, inFile=inFile, outFile=outFile),
      encoding='utf-8', stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True)
@@ -69,8 +67,8 @@ def ExacSolve2(status: ResultStatus) -> None:
 
 def InitResult() -> None:
     """実行結果の出力先ディレクトリを初期化する"""
-    shutil.rmtree(outPath, ignore_errors=True)
-    os.mkdir(outPath)
+    shutil.rmtree(fl.outPath, ignore_errors=True)
+    os.mkdir(fl.outPath)
 
 def InitAll():
     """初期化処理のまとめ
@@ -87,15 +85,13 @@ def ExacTestCaseAndRecordResult(testCasePath: str) -> ResultStatus:
 
     #Solve1.py実行
     fl.SetFileName(testCasePath, "Solve1")
-    fl.SetFileContents()
     ExacSolve1(status)
     #Solve2.py実行
     fl.SetFileName(testCasePath, "Solve2")
-    fl.SetFileContents()
     ExacSolve2(status)
 
     #比較対象のファイルをGet
-    files = glob.glob(os.path.join(outPath, fl.GetOutputFilePath(), "*"))
+    files = glob.glob(os.path.join(fl.outPath, fl.GetOutputFilePath(), "*"))
 
     status.outPaths = files
 

--- a/Debug.py
+++ b/Debug.py
@@ -11,6 +11,7 @@ import shutil
 import filecmp
 from typing import Any
 import traceback
+import subprocess
 
 import TestCaseMaker as tcm
 import FileLib as fl
@@ -19,18 +20,9 @@ from Output import StandardOutput, FileOutput, HTMLOutput
 
 outPath = "out"
 
-####################################
-#Debug用の入出力
-
-def DebugPrint(*arg: Any, **keys: Any) -> None:
-    """実行結果をファイルに出力させる"""
-    f = open(os.path.join(outPath, fl.GetOutputFilePath(), fl.GetOutputFileName()), 'a')
-    print(*arg, **keys, file=f)
-    f.close()
-
-def DebugInput() -> str:
-    """入力をテストケースから読み取る"""
-    return str(fl.fileContents.pop())
+prog1 = "solve1.py"
+prog2 = "solve2.py"
+cmd = "python {name} < {inFile} > {outFile}"
 
 ####################################
 
@@ -43,15 +35,17 @@ def ExacSolve1(status: ResultStatus) -> None:
     """Solve1.pyを実行して実行結果を引数で与えられたクラスに記録する"""
     errFlg = False
     errMsg = None
-    try:
-        import Solve1
-        Solve1.print = DebugPrint
-        Solve1.input = DebugInput
-        Solve1.main()
-    except:
-        errMsg = traceback.format_exc()
+
+    inFile = fl.GetInputFileName()
+    outFile = "out\\case" + str(status.idx) + "\\"+ fl.GetOutputFileName()
+
+    res = subprocess.run(cmd.format(name=prog1, inFile=inFile, outFile=outFile),
+     encoding='utf-8', stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True)
+    
+    if res.returncode != 0:
+        errMsg = res.stderr
         errFlg = True
-    if "Solve1" in sys.modules: del sys.modules["Solve1"]
+    
     status.errFlg1 = errFlg
     status.errMsg1 = errMsg
 
@@ -59,15 +53,17 @@ def ExacSolve2(status: ResultStatus) -> None:
     """Solve2.pyを実行して実行結果を引数で与えられたクラスに記録する"""
     errFlg = False
     errMsg = None
-    try:
-        import Solve2
-        Solve2.print = DebugPrint
-        Solve2.input = DebugInput
-        Solve2.main()
-    except:
-        errMsg = traceback.format_exc()
+
+    inFile = fl.GetInputFileName()
+    outFile = "out\\case" + str(status.idx) + "\\"+ fl.GetOutputFileName()
+
+    res = subprocess.run(cmd.format(name=prog2, inFile=inFile, outFile=outFile),
+     encoding='utf-8', stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, text=True)
+    
+    if res.returncode != 0:
+        errMsg = res.stderr
         errFlg = True
-    if "Solve2" in sys.modules: del sys.modules["Solve2"]
+    
     status.errFlg2 = errFlg
     status.errMsg2 = errMsg
 

--- a/FileLib.py
+++ b/FileLib.py
@@ -28,4 +28,3 @@ def GetOutputFileName() -> str:
 def GetOutputFilePath() -> str:
     """実行結果の出力先パスを取得"""
     return outFilePath
-

--- a/FileLib.py
+++ b/FileLib.py
@@ -2,8 +2,9 @@
 テストケースファイルと実行結果ファイルの名前・パスを保存・読み込みするユーティリティ
 """
 
-import Debug as dl
 import os
+
+outPath = "out"
 
 inputFileName = ""
 outputFileName = ""
@@ -15,21 +16,16 @@ def SetFileName(testCaseName: str, module: str) -> None:
     outputFileName = module + ".txt"
     outFilePath = os.path.basename(testCaseName).split(".")[0]
 
-    os.makedirs(os.path.join(dl.outPath, outFilePath), exist_ok=True)
+    os.makedirs(os.path.join(outPath, outFilePath), exist_ok=True)
 def GetInputFileName() -> str:
-    """実行するテストケースファイル名を取得"""
+    """実行するテストケースファイル名を取得
+    Note: Debug.pyからの相対パスを返す"""
     return inputFileName
 def GetOutputFileName() -> str:
-    """実行結果の出力先のファイル名を取得"""
-    return outputFileName
+    """実行結果の出力先のファイル名を取得
+    Note: Debug.pyからの相対パスを返す"""
+    return os.path.join(outPath, outFilePath, outputFileName)
 def GetOutputFilePath() -> str:
     """実行結果の出力先パスを取得"""
     return outFilePath
 
-fileContents = []
-def SetFileContents() -> None:
-    """テストケースの各行を読み込みfileContentsに保存"""
-    global fileContents
-    path = GetInputFileName()
-    with open(path) as f:
-        fileContents = [s.strip() for s in f.readlines()][::-1]


### PR DESCRIPTION
## 修正内容

### ファイルを実行する形式を入出力リダイレクトのコマンドを使う形式に変更  
メリットを以下に示す
+ DebugInput, DebugPrintを使う必要がなくなる(全体的にコード量が減らせる)
+ main()以下にプログラムを書く制約がなくなる
+ プログラム中にexit()があったときの問題がなくなる (#14 が解決)
+ **python以外の言語も使用できる**

### FileLib.py内の挙動統一
GetInputFileName()→相対パス含む名前(/in/caseX.txt)
GetOutputFileName()→名前だけ(Solve1.txt)
似た名前の関数の挙動が違っているのが気になったので両方Debug.pyの位置からの相対パスを返すようにした
(あくまでついででメインの修正は上のやつ)

## 確認点
・Win環境で従来と同じ挙動となる
　出力ファイルが正常に作成・HTMLのリンクから見れること
　エラーがないとき、作成されるHTMLファイルが従来と同じこと
　エラーが発生したとき、作成されるHTMLファイルが従来と同じこと

@dorapon2000  
Mac環境でも動くか一応確認お願い  
急がないので時間があるときでOKです
